### PR TITLE
Update fit methods to use ::Type{M} interface

### DIFF
--- a/src/models/kmeans.jl
+++ b/src/models/kmeans.jl
@@ -10,8 +10,6 @@ struct kMeansModel <: DischargeModel
     Q::Vector{Float64}
 end
 
-kMeansModel(M,N,k=1,λ=0.0) = kMeansModel(M,k,λ,zeros(M,k),zeros(M,k),zeros(M,N),zeros(N))
-
 function clusters(M::kMeansModel,H)
     D = pairwise(Euclidean(),H,M.centers, dims=2)
     map(x->x[2], findmin(D, dims=2)[2])

--- a/src/models/kmeans.jl
+++ b/src/models/kmeans.jl
@@ -28,12 +28,20 @@ function StatsBase.fit(M::kMeansModel,H::Matrix{Float64},Q::Vector{Float64})
     kMeansModel(M.M,M.k,M.λ,km.centers,β,H,Q)
 end
 
-function StatsBase.fit(m::kMeansModel, h::Vector{Float64}, Q::Vector{Float64})
-    H = zeros(m.M, length(h) - m.M + 1)
-    for i in 1:m.M
-        H[m.M - i + 1, :] = h[i:end - m.M + i]
+function StatsBase.fit(::Type{kMeansModel}, h::Vector{Float64}, Q::Vector{Float64}; M=1, k=1, λ=0.0)
+    H = zeros(M, length(h) - M + 1)
+    for i in 1:M
+        H[M - i + 1, :] = h[i:end - M + i]
     end
-    fit(m, H, Q[m.M:end])
+    Qt = Q[M:end]
+    km = kmeans(H,k,init=:kmcen,tol=1e-32)
+    β = zeros(M,k)
+    for i in 1:k
+        Hi = H[:,assignments(km).==i]
+        Qi = Qt[assignments(km).==i]
+        β[:,i] = (Hi*Hi'+λ*I)\(Hi*Qi)
+    end
+    kMeansModel(M,k,λ,km.centers,β,H,Qt)
 end
 
 function StatsBase.fit!(M::kMeansModel,H::Matrix{Float64},Q::Vector{Float64})

--- a/src/models/knn.jl
+++ b/src/models/knn.jl
@@ -22,12 +22,12 @@ function StatsBase.fit(m::KNNModel, H::Matrix{Float64}, Q::Vector{Float64})
     KNNModel(m.M, m.k, KDTree(H), Q, zeros(Int, m.k), zeros(Float64, m.k))
 end
 
-function StatsBase.fit(m::KNNModel, h::Vector{Float64}, Q::Vector{Float64})
-    H = zeros(m.M, length(h) - m.M + 1)
-    for i in 1:m.M
-        H[i, :] = h[i:end - m.M + i]
+function StatsBase.fit(::Type{KNNModel}, h::Vector{Float64}, Q::Vector{Float64}; M=1, k=1)
+    H = zeros(M, length(h) - M + 1)
+    for i in 1:M
+        H[M - i + 1, :] = h[i:end - M + i]
     end
-    KNNModel(m.M, m.k, KDTree(H), Q[m.M:end], zeros(Int, m.k), zeros(Float64, m.k))
+    KNNModel(M, k, KDTree(H), Q[M:end], zeros(Int, k), zeros(Float64, k))
 end
 
 StatsBase.predict(m::KNNModel) = predict(m, m.t.data)

--- a/src/models/knn.jl
+++ b/src/models/knn.jl
@@ -11,8 +11,6 @@ struct KNNModel <: DischargeModel
     dist::Vector{Float64}    
 end
 
-KNNModel(M, k) = KNNModel(M, k, nothing, Float64[], zeros(Int, k), zeros(Float64, k))
-
 function StatsBase.fit!(m::KNNModel, H::Matrix{Float64}, Q::Vector{Float64})
     m.t = KDTree(H)
     m.Q = Q

--- a/test/kmeans.jl
+++ b/test/kmeans.jl
@@ -1,5 +1,4 @@
-m = kMeansModel(3, 0, 27, 0.0)
-m = fit(m, data[!,:Stage], data[!,:Discharge])
+m = fit(kMeansModel, data[!,:Stage], data[!,:Discharge], M=3, k=27)
 Qpp = predict(m, test_data[!, :Stage])
 
 @test length(Qpp) == length(test_data[!, :Stage])

--- a/test/knn.jl
+++ b/test/knn.jl
@@ -1,5 +1,4 @@
-m = KNNModel(4, 10)
-m = fit(m, data[!,:Stage], data[!,:Discharge])
+m = fit(KNNModel, data[!,:Stage], data[!,:Discharge], M=4, k=10)
 Qpp = predict(m, test_data[!, :Stage])
 
 @test length(Qpp) == length(test_data[!, :Stage])


### PR DESCRIPTION
This avoids the awkward step of constructing a model object before it
is fitted.