### PR TITLE
Refactor to support missing data

### DIFF
--- a/src/dischargemodels.jl
+++ b/src/dischargemodels.jl
@@ -70,11 +70,6 @@ StatsBase.fit(M::DischargeModel, Y::Matrix{Float64}) = fit(M,Y[1:end-1,:],vec(Y[
 
 StatsBase.fit!(M::DischargeModel,Y::Matrix{Float64}) = fit!(M,Y[1:end-1,:],vec(Y[end,:]))
 
-function StatsBase.predict(model::M, h::Vector{Float64}) where {M <: DischargeModel}
-    Ht = validate(lagmatrix(h), 1:length(h), model.M)
-    predict(model, Ht)
-end
-
 # Functions for fitting from a Discharge type
 
 estfun!(M::DischargeModel,h::Vector{Float64},dd::Vector{Float64},range) = estfun!(M,lagmatrix(h),dd,range)

--- a/test/kmeans.jl
+++ b/test/kmeans.jl
@@ -1,5 +1,28 @@
-m = fit(kMeansModel, data[!,:Stage], data[!,:Discharge], M=3, k=27)
-Qpp = predict(m, test_data[!, :Stage])
+@testset "kMeansModel" begin
+    m = fit(kMeansModel, data[!,:Stage], data[!,:Discharge], M=3, k=27)
+    Qpp = predict(m, test_data[!, :Stage])
+    
+    @test length(Qpp) == length(test_data[!, :Stage])
+    @test count(ismissing, Qpp) == 2
+end
 
-@test length(Qpp) == length(test_data[!, :Stage])
-@test count(ismissing, Qpp) == 2
+@testset "kMeansModel with missing data" begin
+    h = Array{Union{Missing, Float64}}(randn(200))
+    h[10] = missing
+
+    q = Array{Union{Missing, Float64}}(randn(200))
+    q[24] = missing
+
+    m = fit(kMeansModel, h, q, M=3, k=27)
+
+    ht = Array{Union{Missing, Float64}}(randn(100))
+    ht[73] = missing
+
+    Qpp = predict(m, ht)
+
+    @test length(Qpp) == 100
+
+    # M-1 points at the beginning + M points around the single missing
+    # value
+    @test count(ismissing, Qpp) == 5
+end

--- a/test/knn.jl
+++ b/test/knn.jl
@@ -1,6 +1,29 @@
-m = fit(KNNModel, data[!,:Stage], data[!,:Discharge], M=4, k=10)
-Qpp = predict(m, test_data[!, :Stage])
+@testset "KNNModel" begin
+    m = fit(KNNModel, data[!,:Stage], data[!,:Discharge], M=4, k=10)
+    Qpp = predict(m, test_data[!, :Stage])
 
-@test length(Qpp) == length(test_data[!, :Stage])
-@test count(ismissing, Qpp) == 3
+    @test length(Qpp) == length(test_data[!, :Stage])
+    @test count(ismissing, Qpp) == 3
+end
+
+@testset "KNNModel with missing data" begin
+    h = Array{Union{Missing, Float64}}(randn(200))
+    h[10] = missing
+
+    q = Array{Union{Missing, Float64}}(randn(200))
+    q[24] = missing
+
+    m = fit(KNNModel, h, q, M=3, k=27)
+
+    ht = Array{Union{Missing, Float64}}(randn(100))
+    ht[73] = missing
+
+    Qpp = predict(m, ht)
+
+    @test length(Qpp) == 100
+
+    # M-1 points at the beginning + M points around the single missing
+    # value
+    @test count(ismissing, Qpp) == 5
+end
 


### PR DESCRIPTION
The models handle missing data in the following way. At training time, any missing stage or discharge data points are discarded. This discards a window around each missing stage data point, because there the missing data point shows up in the lagged vectors within that window. At test time, the windows around missing stage points are discarded.