### PR TITLE
Refactor to support multiple data sets

### DIFF
--- a/test/kmeans.jl
+++ b/test/kmeans.jl
@@ -13,7 +13,7 @@ end
     q = Array{Union{Missing, Float64}}(randn(200))
     q[24] = missing
 
-    m = fit(kMeansModel, h, q, M=3, k=27)
+    m = fit(kMeansModel, h, q, M=3, k=27, λ = 1.0)
 
     ht = Array{Union{Missing, Float64}}(randn(100))
     ht[73] = missing
@@ -25,4 +25,15 @@ end
     # M-1 points at the beginning + M points around the single missing
     # value
     @test count(ismissing, Qpp) == 5
+end
+
+@testset "kMeansModel with multiple data sets" begin
+    h1 = randn(200)
+    q1 = randn(200)
+    h2 = randn(200)
+    q2 = randn(200)
+
+    m0 = fit(kMeansModel, [h1, h2], [q1, q2], M=10, k=10)
+
+    @assert length(m0.Q) == 400 - 18
 end

--- a/test/knn.jl
+++ b/test/knn.jl
@@ -27,3 +27,13 @@ end
     @test count(ismissing, Qpp) == 5
 end
 
+@testset "KNNModel with multiple data sets" begin
+    h1 = randn(200)
+    q1 = randn(200)
+    h2 = randn(200)
+    q2 = randn(200)
+
+    m0 = fit(KNNModel, [h1, h2], [q1, q2], M=10, k=10)
+
+    @assert length(m0.Q) == 400 - 18
+end


### PR DESCRIPTION
Concatenating time series and fitting the models is not correct, because it constructs windows out of multiple time series. Instead, one needs to construct design matrix and response vectors for each time series and concatenate those. A preparedata method is added that does this, and the fit methods for KNNModel and kMeansModel continue to work without changes.

Tests are added to make sure that vectors of vectors work.